### PR TITLE
fix : 루트 레이아웃 높이 고정 및 플레이리스트 오버플로우 이슈 픽스

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Providers>
           <main className="bg-color-background-primary w-full h-screen grid grid-cols-[max-content_auto] grid-rows-[1fr_auto] p-2 gap-2">
             <Sidebar />
-            <div className="flex flex-col">
+            <div className="flex flex-col h-[calc(100vh-72px)s] overflow-y-auto">
               <Header />
               {children}
             </div>

--- a/src/app/playlist/PlaylistTrackProvider.tsx
+++ b/src/app/playlist/PlaylistTrackProvider.tsx
@@ -14,7 +14,7 @@ export const PlaylistTracksContext = createContext<{
   setPlaylistTracks: React.Dispatch<React.SetStateAction<playlistTrack[]>>
 }>({
   playlistTracks: [],
-  setPlaylistTracks: () => { },
+  setPlaylistTracks: () => {},
 })
 
 export function PlaylistTrackProvider({ children }) {

--- a/src/app/playlist/Playlists.tsx
+++ b/src/app/playlist/Playlists.tsx
@@ -13,7 +13,7 @@ export default function Playlists() {
         <SlOptions size={24} className="text-color-text-secondary" />
       </div>
       <div>
-        <div className="w-full h-24 ">
+        <div className="w-full h-full text-color-text-secondary">
           {playlistTracks.map((item) => (
             <div className="relative flex flex-row px-2 py-3" key={item.id}>
               <Image className="mr-3" src={item.img} width={40} height={40} alt="track image" />

--- a/src/app/playlist/SearchResult.tsx
+++ b/src/app/playlist/SearchResult.tsx
@@ -24,13 +24,13 @@ export default function SearchResult({ data }) {
   return (
     <div className="">
       {data?.tracks.items.map((item) => (
-        <div className="relative flex flex-row px-2 py-3 " key={item.id}>
+        <div className="relative flex flex-row px-2 py-3 text-color-text-secondary" key={item.id}>
           <Image className="mr-3" src={item.album.images[0]?.url} width={40} height={40} alt="item image" />
           <div>
             <p className="font-bold">{item.name}</p>
-            <p className="text-sm font-semibold text-[#B3B3B3]">{item.artists[0]?.name}</p>
+            <p className="text-sm font-semibold">{item.artists[0]?.name}</p>
           </div>
-          <div className="absolute text-right top-5 text-[#B3B3B3] text-sm right-48">{item.album?.name}</div>
+          <div className="absolute text-right top-5  text-sm right-48">{item.album?.name}</div>
           <button className="absolute right-10 top-5" onClick={() => addTrack(item)}>
             추가하기
           </button>


### PR DESCRIPTION
root layout에서 메인 페이지의 높이를 지정하지 않아서 생기는 오버플로우 이슈 픽스

플레이리스트에서 track 추가시 플레이리스트 컴포넌트 오버플로우 이슈 픽스